### PR TITLE
Fix bug with string in log metrics, talos scan params

### DIFF
--- a/stock_pred_talos.py
+++ b/stock_pred_talos.py
@@ -166,8 +166,8 @@ class LogMetrics(Callback):
 
     def on_epoch_end(self, epoch, logs):
         for i, key in enumerate(self.self_params.keys()):
-            if not type(self.param[key]) is str: logs[key] = self.param[key]
-            else: logs[key] = self.self_params[key].index(self.param[key])
+            if type(self.param[key]) is str: logs[key] = self.self_params[key].index(self.param[key])
+            else: logs[key] = self.param[key]
         logs["combination_number"] = self.comb_no
 
 

--- a/stock_pred_talos.py
+++ b/stock_pred_talos.py
@@ -166,7 +166,7 @@ class LogMetrics(Callback):
 
     def on_epoch_end(self, epoch, logs):
         for i, key in enumerate(self.self_params.keys()):
-            if type(self.param[key]) is str: logs[key] = self.self_params[key].index(self.param[key])
+            if type(self.param[key]) is str and type(self.self_params[key]) is list: logs[key] = self.self_params[key].index(self.param[key])
             else: logs[key] = self.param[key]
         logs["combination_number"] = self.comb_no
 

--- a/stock_pred_talos.py
+++ b/stock_pred_talos.py
@@ -166,7 +166,8 @@ class LogMetrics(Callback):
 
     def on_epoch_end(self, epoch, logs):
         for i, key in enumerate(self.self_params.keys()):
-            logs[key] = self.param[key]
+            if not type(self.param[key]) is str: logs[key] = self.param[key]
+            else: logs[key] = self.self_params[key].index(self.param[key])
         logs["combination_number"] = self.comb_no
 
 
@@ -260,8 +261,9 @@ t = ta.Scan(x=mat,
             y=mat[:,0],
             model=create_model_talos,
             params=search_params,
-            dataset_name='stock_ge',
-            experiment_no='1')
+            experiment_name='stock_ge[1]')
+            #dataset_name='stock_ge',
+            #experiment_no='1')
 
 pickle.dump(t, open(os.path.join(OUTPUT_PATH,"talos_res"),"wb"))
 


### PR DESCRIPTION
```
Epoch 30/30
 - 6s - loss: 0.0012 - val_loss: 2.2995
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 791, in opt_hyperparam_talos
  File "C:\Program Files\Python37\lib\site-packages\talos\scan\Scan.py", line 196, in __init__
    self._runtime()
  File "C:\Program Files\Python37\lib\site-packages\talos\scan\Scan.py", line 201, in _runtime
    self = scan_run(self)
  File "C:\Program Files\Python37\lib\site-packages\talos\scan\scan_run.py", line 26, in scan_run
    self = scan_round(self)
  File "C:\Program Files\Python37\lib\site-packages\talos\scan\scan_round.py", line 24, in scan_round
    self = logging_run(self, round_start, start, self.model_history)
  File "C:\Program Files\Python37\lib\site-packages\talos\logging\logging_run.py", line 33, in logging_run
    self.epoch_entropy.append(epoch_entropy(self, model_history.history))
  File "C:\Program Files\Python37\lib\site-packages\talos\metrics\entropy.py", line 38, in epoch_entropy
    out.append(entropy(history[self._metric_keys[i]]))
  File "C:\Program Files\Python37\lib\site-packages\scipy\stats\_distn_infrastructure.py", line 2544, in entropy
    pk = 1.0*pk / np.sum(pk, axis=0)
numpy.core._exceptions.UFuncTypeError: ufunc 'multiply' did not contain a loop with signature matching types (dtype('<U32'), dtype('<U32')) -> dtype('<U32')
```

A reasonable fix was simply check for strings and instead discretize them by returning indexes.

Also note that experiment_name in current talos installs is used instead of dataset_name/experiment_no

It can be reused with the hyperopt version too as this restriction is not found in fmin as it does not do numeric calculations on the result of the metrics in the same way.  That is actually a hyperopt.pyll.base.Apply object so it cannot be indexed so nicely, and for float/int also the normal case applies.